### PR TITLE
Sync localHub documentation with code

### DIFF
--- a/man/ExperimentHub-class.Rd
+++ b/man/ExperimentHub-class.Rd
@@ -65,7 +65,7 @@
       \code{ExperimentHub(..., hub=getExperimentHubOption("URL"),
 	cache=getExperimentHubOption("CACHE"),
 	proxy=getExperimentHubOption("PROXY"),
-	localHub=getExperimentHubOption("LOCALHUB"))}:
+	localHub=getExperimentHubOption("LOCAL"))}:
 
       Create an \code{ExperimentHub} instance, possibly updating the
       current database of records.


### PR DESCRIPTION
Looks like the documentation fell out of sync with the code
```R
# Documentation
> getExperimentHubOption("LOCALHUB")
Error in getExperimentHubOption("LOCALHUB") : 
  'arg' must be one of 'URL', 'CACHE', 'PROXY', 'LOCAL', or 'MAXDOWNLOADS'
# Code
> args(ExperimentHub)
function (..., hub = getExperimentHubOption("URL"), cache = getExperimentHubOption("CACHE"), 
    proxy = getExperimentHubOption("PROXY"), localHub = getExperimentHubOption("LOCAL")) 
NULL
```
