### PR TITLE
Improvements to the ExperimentHub constructor

### DIFF
--- a/R/ExperimentHub-class.R
+++ b/R/ExperimentHub-class.R
@@ -17,15 +17,15 @@ ExperimentHub <-
              ask=getExperimentHubOption("ASK"))
 {
     if (is.null(proxy)){
-        connect <- curl::has_internet()
+        connect <- !is.null(curl::nslookup("experimenthub.bioconductor.org", error=FALSE))
     } else {
         connect <- TRUE
-        message("Cannot determine internet connection.",
-                "\n If you experience connection issues consider ",
+        message(sprintf("assuming valid proxy connection (%s).", proxy),
+                "\nIf you experience connection issues, consider ",
                 "using 'localHub=TRUE'")
     }
     if (!connect && !localHub){
-        message("No internet connection using 'localHub=TRUE'")
+        message("cannot connect to ExperimentHub servers, using 'localHub=TRUE' instead")
         localHub <- !connect
     }
     .Hub("ExperimentHub", hub, cache, proxy, localHub, ask, ...)

--- a/R/ExperimentHub-class.R
+++ b/R/ExperimentHub-class.R
@@ -20,12 +20,12 @@ ExperimentHub <-
         connect <- !is.null(curl::nslookup("experimenthub.bioconductor.org", error=FALSE))
     } else {
         connect <- TRUE
-        message(sprintf("assuming valid proxy connection (%s).", proxy),
+        message(sprintf("Assuming valid proxy connection through '%s'.", proxy),
                 "\nIf you experience connection issues, consider ",
-                "using 'localHub=TRUE'")
+                "using 'localHub=TRUE'.")
     }
     if (!connect && !localHub){
-        message("cannot connect to ExperimentHub servers, using 'localHub=TRUE' instead")
+        message("Cannot connect to ExperimentHub server, using 'localHub=TRUE' instead.")
         localHub <- !connect
     }
     .Hub("ExperimentHub", hub, cache, proxy, localHub, ask, ...)


### PR DESCRIPTION
We perform a DNS lookup directly to the ExperimentHub server rather than using Google, to avoid failures for those users who happen to not have access to Google (heaven forbid).

I also took the liberty of cleaning up the notification messages; this closes #12.