### PR TITLE
Use requireNamespace() to test for pkg availability

### DIFF
--- a/R/ExperimentHub-class.R
+++ b/R/ExperimentHub-class.R
@@ -94,7 +94,7 @@ setMethod("cache", "ExperimentHub",
     nopkg <- paste0(pkg,
                     " not installed.\n  Full functionality, documentation, ",
                     "and loading of data might not be possible without installing")
-    if (!pkg %in% rownames(installed.packages())){
+    if (!requireNamespace(pkg, quietly = TRUE)){
         message(nopkg)
         if (interactive() &&
             identical(AnnotationHub:::.ask(
@@ -105,7 +105,7 @@ setMethod("cache", "ExperimentHub",
             BiocManager::install(pkg, update=FALSE)
         }
     }
-    if (pkg %in% rownames(installed.packages())) {
+    if (requireNamespace(pkg, quietly = TRUE)) {
         suppressPackageStartupMessages({
             require(pkg, quietly = TRUE, character.only = TRUE)
         })


### PR DESCRIPTION
As recommended in ?installed.packages():

> This needs to read several files per installed package, which will be slow on Windows and on some network-mounted file systems.
> 
> It will be slow when thousands of packages are installed, so do not use it to find out if a named package is installed (use find.package or system.file) nor to find out if a package is usable (call requireNamespace or require and check the return value) nor to find details of a small number of packages (use packageDescription).

The difference is already quite marked on my Linux system, with not that many packages. So probably even more noticeable in the situations described in the help page:

``` r
microbenchmark::microbenchmark(
  { "BiocManager" %in% rownames(installed.packages()) },
  requireNamespace("BiocManager", quietly = TRUE),
  check = "identical",
  times = 1e3 
)
#> Unit: nanoseconds
#>                                                       expr     min      lq
#>  {     "BiocManager" %in% rownames(installed.packages()) } 3391099 3610066
#>            requireNamespace("BiocManager", quietly = TRUE)     795    1096
#>         mean    median        uq     max neval cld
#>  4036229.134 3853698.5 4126194.5 8235825  1000  a 
#>     2928.419    2720.5    3475.5   45586  1000   b

nrow(installed.packages())
#> [1] 894
```

<sup>Created on 2025-09-16 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>